### PR TITLE
Alyssa working

### DIFF
--- a/second_cplex/second_cplex.mod
+++ b/second_cplex/second_cplex.mod
@@ -87,6 +87,7 @@ execute {
 }
 
 int rijkt = 1;
+int gymCap = 1;
 
 //decision variables
 dvar boolean x[r1][r2][r3][r4]; //x is the binary location variable, 'boolean' defines a binary variable
@@ -151,6 +152,9 @@ subject to //constraints are declared below
 	
 	//teaching mins
 	forall(j in r2) sum(t in r4, i in subjects, k in class) lengtht[t]*x[i,j,k,t] <= teachMin[j];
+	
+	//gym capacity
+	forall(t in r4) sum(j in r2, k in r3)x[6,j,k,t] <= gymCap;
 }
 
 int mathTime[class];

--- a/second_cplex/second_cplex.mod
+++ b/second_cplex/second_cplex.mod
@@ -13,6 +13,7 @@ range subjects = 1..7;
 string subj[r1] = ["Math", "Language","Science", "Art", "Social Studies", "Phys-Ed", "French", "Away", "Prep"];
 int prepSubject = N;
 int awaySubject = N-1;
+range subjectRange = N..N;
 
 //j = teacher
 int N2=11;
@@ -28,6 +29,7 @@ range r3 = 1..N3;
 range class = 1..(N3-1);
 int prepCohort = N3;
 int awayCohort = N3-1;
+range cohortRange = N3..N3;
 
 //t = time
 int N4=30;
@@ -43,6 +45,19 @@ int totalTime = 1500;
 float totalTeacherMin[r2];
 float prep[r2];
 float teachMin[r2];
+
+//time periods teachers are available- this will need to be automated from the user input
+int availableTime[r2][r4]= [[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,0,0,0,0,0,0,0,0],
+							[1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1]];
 
 execute {
 
@@ -86,6 +101,9 @@ subject to //constraints are declared below
 	
 	//teacher can only teach one subject/class at a time- new constraint
 	forall(j in r2, t in r4) sum(i in r1, k in r3)x[i,j,k,t] == 1;
+	
+	//teacher can only teach one subject/class at a time - make this only for prep and teaching periods
+	forall(j in r2, t in r4) sum(i in subjects, k in class)x[i,j,k,t] + sum(i in subjectRange, k in cohortRange)x[i,j,k,t]  == 1* availableTime[j][t];
 	
 	//assignment2 - at every time, each cohort needs only one teacher and one subject
 	forall(k in class, t in r4) sum(i in subjects, j in r2)x[i,j,k,t] == 1;


### PR DESCRIPTION
Part Time teachers:
This commit will only allow part time teachers to be scheduled if they are available for those days/time frames. The matrix is for every teacher and every t. If the value is 1, they are available, 0 o/w.  New constraint added to reflect this.

to test:
-there is only one part time teacher (teacher 10) ->make sure that the "0's in the array match the time periods the teacher is scheduled for "away" 
-none of the full time teachers are scheduled as away

Gym capacity:
-had to change the constraint from a "for all teachers" to sum over teachers (made a card to change in model)
-only schedule gym if capacity isnt full

to test:
-I made the gym cap as 1: make sure only one cohort is scheduled in the gym at one time